### PR TITLE
Signaler à Java qu'il peut utiliser toute (95%) la RAM dispo qu'on limite par ailleurs avec le paramètre plus haut mem_limit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,8 @@ services:
       SPRING_DATASOURCE_BASEXML_PASSWORD: ${QUALIMARC_API_SPRING_DATASOURCE_BASEXML_PASSWORD}
       JWT_SECRET: ${QUALIMARC_API_JWT_SECRET}
       JWT_ANONYMOUSUSER: ${QUALIMARC_API_JWT_ANONYMOUS_USER}
+      # Pour signaler à Java qu'il peut utiliser toute (95%) la RAM dispo qu'on limite par ailleurs avec le paramètre plus haut mem_limit
+      JVM_OPTS: "-XX:MaxRAMPercentage=95"
     ports:
       - ${QUALIMARC_API_HTTP_PORT}:8082
     depends_on:
@@ -106,6 +108,8 @@ services:
       SPRING_DATASOURCE_QUALIMARC_JDBCURL: 'jdbc:postgresql://qualimarc-db:5432/qualimarc'
       SPRING_DATASOURCE_QUALIMARC_USERNAME: ${QUALIMARC_DB_POSTGRES_USER}
       SPRING_DATASOURCE_QUALIMARC_PASSWORD: ${QUALIMARC_DB_POSTGRES_PASSWORD}
+      # Pour signaler à Java qu'il peut utiliser toute (95%) la RAM dispo qu'on limite par ailleurs avec le paramètre plus haut mem_limit
+      JVM_OPTS: "-XX:MaxRAMPercentage=95"
     labels:
       # pour envoyer les logs dans le puits de log de l'abes
       - "co.elastic.logs/enabled=true"


### PR DESCRIPTION
cf l'article suivant trouvé par @julg :
https://stackoverflow.com/questions/29923531/how-to-set-java-heap-size-xms-xmx-inside-docker-container

qui dit ceci : 

> Update: Regarding this discussion, Java has upped there game regarding container support. Nowadays (or since JVM version 10 to be more exact), the JVM is smart enough to figure out whether it is running in a container, and if yes, how much memory it is limited to.
> So, rather than setting fixed limits when starting your JVM, which you then have to change in line with changes to your container limits (resource limits in the K8s world), simply do nothing and let the JVM work out limits for itself.

et un peu plus bas ceci : 

> Without any extra configuration, the JVM will set the maximum heap size to 25% of the allocated memory.

et ceci : 
> Since this is frugal, you might want to ramp that up a bit by setting the -XX:MaxRAMPercentage attribute.